### PR TITLE
Fix: Migrate fragment to fragment support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.21'
     ext.android_support_version = '27.1.1'
 
 

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 apply from: 'versioning.gradle'
 
 group = 'io.clappr.player'
-version = '0.17.0'
+version = '0.17.1'
 
 def publishAttrs = buildPublishAttrs(version)
 

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 apply from: 'versioning.gradle'
 
 group = 'io.clappr.player'
-version = '0.16.0'
+version = '0.17.0'
 
 def publishAttrs = buildPublishAttrs(version)
 

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 apply from: 'versioning.gradle'
 
 group = 'io.clappr.player'
-version = '0.15.0'
+version = '0.16.0'
 
 def publishAttrs = buildPublishAttrs(version)
 

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 apply from: 'versioning.gradle'
 
 group = 'io.clappr.player'
-version = '0.17.1'
+version = '0.17.2'
 
 def publishAttrs = buildPublishAttrs(version)
 

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 apply from: 'versioning.gradle'
 
 group = 'io.clappr.player'
-version = '0.17.3'
+version = '0.18.0'
 
 def publishAttrs = buildPublishAttrs(version)
 

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:3.8"
     testImplementation 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
 }
 
 tasks.matching {it instanceof Test}.all {

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 apply from: 'versioning.gradle'
 
 group = 'io.clappr.player'
-version = '0.17.2'
+version = '0.17.3'
 
 def publishAttrs = buildPublishAttrs(version)
 

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -81,12 +81,13 @@ open class Player(private val base: BaseObject = BaseObject(),
             field = value
             updateCoreFullScreenStatus()
             core?.let {
-                it.on(InternalEvent.WILL_CHANGE_ACTIVE_PLAYBACK.value, { _ -> unbindPlaybackEvents() })
-                it.on(InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value, { _ -> bindPlaybackEvents() })
-                it.on(InternalEvent.WILL_CHANGE_ACTIVE_CONTAINER.value, { _ -> unbindContainerEvents() })
-                it.on(InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value, { _ -> bindContainerEvents() })
-                it.on(Event.REQUEST_FULLSCREEN.value, { bundle: Bundle? -> trigger(Event.REQUEST_FULLSCREEN.value, bundle) })
-                it.on(Event.EXIT_FULLSCREEN.value, { bundle: Bundle? -> trigger(Event.EXIT_FULLSCREEN.value, bundle) })
+                it.on(InternalEvent.WILL_CHANGE_ACTIVE_PLAYBACK.value) { unbindPlaybackEvents() }
+                it.on(InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value) { bindPlaybackEvents() }
+                it.on(InternalEvent.WILL_CHANGE_ACTIVE_CONTAINER.value) { unbindContainerEvents() }
+                it.on(InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value) { bindContainerEvents() }
+                it.on(Event.REQUEST_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.REQUEST_FULLSCREEN.value, bundle) }
+                it.on(Event.EXIT_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.EXIT_FULLSCREEN.value, bundle) }
+                it.on(Event.MEDIA_OPTIONS_SELECTED.value) { bundle: Bundle? -> trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle) }
 
                 if (it.activeContainer != null) {
                     bindContainerEvents()

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -247,7 +247,7 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun bindPlaybackEvents() {
         core?.activePlayback?.let {
-            playbackEventsToListen.mapTo(playbackEventsIds) { event -> listenTo(it, event, { bundle: Bundle? -> trigger(event, bundle) }) }
+            playbackEventsToListen.mapTo(playbackEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
         }
     }
 
@@ -260,7 +260,7 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun bindContainerEvents() {
         core?.activeContainer?.let {
-            containerEventsToListen.mapTo(containerEventsIds) { event -> listenTo(it, event, { bundle: Bundle? -> trigger(event, bundle) }) }
+            containerEventsToListen.mapTo(containerEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
         }
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -99,9 +99,15 @@ enum class Event(val value: String) {
     DID_UPDATE_POSTER("didUpdatePoster"),
 
     /**
-     * Media Options Selected. Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE] key.
+     * Media Options Selected. Triggered when the user select a Media Option.
+     * Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE] key.
      */
     MEDIA_OPTIONS_SELECTED("mediaOptionsSelected"),
+
+    /**
+     * Media Options Update. Triggered when the Playback load a media option
+     */
+    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
 
     /**
      * There was a change in DVR status

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -33,5 +33,7 @@ enum class InternalEvent (val value: String) {
     WILL_SHOW_MEDIA_CONTROL("willShowMediaControl"),
     WILL_HIDE_MEDIA_CONTROL("willHideMediaControl"),
     DID_HIDE_MEDIA_CONTROL("didHideMediaControl"),
-    DID_SHOW_MEDIA_CONTROL("didShowMediaControl")
+    DID_SHOW_MEDIA_CONTROL("didShowMediaControl"),
+
+    DID_RESIZE("didResize")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -17,7 +17,6 @@ enum class InternalEvent (val value: String) {
     WILL_DESTROY("willDestroy"),
     DID_DESTROY("didDestroy"),
     MEDIA_OPTIONS_READY("mediaOptionsReady"),
-    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
     DID_UPDATE_OPTIONS("didUpdateOptions"),
 
     DID_TOUCH_MEDIA_CONTROL("didTouchMediaControl"),

--- a/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
@@ -42,7 +42,8 @@ enum class ClapprOption(val value: String) {
      */
     MEDIA_CONTROL_PLUGINS("mediaControlPlugins"),
     /**
-     *  If you want the video to automatically replay after it ends.
+     *  If true the video will be played forever (loop mode).
+     *  If false the video will be stopped when it ends
      */
     LOOP("loop")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
@@ -40,5 +40,9 @@ enum class ClapprOption(val value: String) {
     /**
      * The sequence in which the plugins will be displayed in the media control. Names are separated by commas and are case sensitive.
      */
-    MEDIA_CONTROL_PLUGINS("mediaControlPlugins")
+    MEDIA_CONTROL_PLUGINS("mediaControlPlugins"),
+    /**
+     *  If you want the video to automatically replay after it ends.
+     */
+    LOOP("loop")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -85,15 +85,10 @@ class Core(options: Options) : UIObject() {
 
     private val layoutChangeListener = View.OnLayoutChangeListener { _, left, top, right, bottom,
                                                                      oldLeft, oldTop, oldRight, oldBottom ->
-        val horizontal = right - left
-        val oldHorizontal = oldRight - oldLeft
+        val horizontalChange = (right - left) != (oldRight - oldLeft)
+        val verticalChange = (bottom - top) != (oldBottom - oldTop)
 
-        val vertical = bottom - top
-        val oldVertical = oldBottom - oldTop
-
-        if (horizontal != oldHorizontal || vertical != oldVertical) {
-            trigger(InternalEvent.DID_RESIZE.value)
-        }
+        if (horizontalChange || verticalChange) { trigger(InternalEvent.DID_RESIZE.value) }
     }
 
     init {

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -1,6 +1,7 @@
 package io.clappr.player.components
 
 import android.os.Bundle
+import android.view.View
 import android.widget.FrameLayout
 import io.clappr.player.base.InternalEvent
 import io.clappr.player.base.Options
@@ -82,6 +83,19 @@ class Core(options: Options) : UIObject() {
     override val viewClass: Class<*>
         get() = FrameLayout::class.java
 
+    private val layoutChangeListener = View.OnLayoutChangeListener { _, left, top, right, bottom,
+                                                                     oldLeft, oldTop, oldRight, oldBottom ->
+        val horizontal = right - left
+        val oldHorizontal = oldRight - oldLeft
+
+        val vertical = bottom - top
+        val oldVertical = oldBottom - oldTop
+
+        if (horizontal != oldHorizontal || vertical != oldVertical) {
+            trigger(InternalEvent.DID_RESIZE.value)
+        }
+    }
+
     init {
         internalPlugins = Loader.loadPlugins(this).toMutableList()
 
@@ -107,6 +121,7 @@ class Core(options: Options) : UIObject() {
         }
         internalPlugins.clear()
         stopListening()
+        frameLayout.removeOnLayoutChangeListener(layoutChangeListener)
         trigger(InternalEvent.DID_DESTROY.value)
     }
 
@@ -122,6 +137,10 @@ class Core(options: Options) : UIObject() {
                     { it.render() },
                     "Plugin ${it.javaClass.simpleName} crashed during render")
         }
+
+        frameLayout.removeOnLayoutChangeListener(layoutChangeListener)
+        frameLayout.addOnLayoutChangeListener(layoutChangeListener)
+
         return this
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -1,9 +1,7 @@
 package io.clappr.player.components
 
-import android.os.Bundle
 import io.clappr.player.base.*
 import io.clappr.player.log.Logger
-import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.*
@@ -129,11 +127,14 @@ abstract class Playback(
     }
 
     protected var mediaOptionList = LinkedList<MediaOption>()
-    protected var selectedMediaOptionList = ArrayList<MediaOption>()
+    var selectedMediaOptionList = ArrayList<MediaOption>()
+        private set
 
-    private val mediaOptionsArrayJson = "media_option"
-    private val mediaOptionsNameJson = "name"
-    private val mediaOptionsTypeJson = "type"
+    companion object {
+        const val mediaOptionsArrayJson = "media_option"
+        const val mediaOptionsNameJson = "name"
+        const val mediaOptionsTypeJson = "type"
+    }
 
     fun addAvailableMediaOption(media: MediaOption, index: Int = mediaOptionList.size) {
         mediaOptionList.add(index, media)
@@ -171,23 +172,6 @@ abstract class Playback(
         selectedMediaOptionList.add(mediaOption)
 
         trigger(InternalEvent.MEDIA_OPTIONS_UPDATE.value)
-
-        val bundle = Bundle()
-        bundle.putString(EventData.MEDIA_OPTIONS_SELECTED_RESPONSE.value, convertSelectedMediaOptionsToJson())
-        trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle)
-    }
-
-    private fun convertSelectedMediaOptionsToJson(): String {
-        val result = JSONObject()
-        val jsonArray = JSONArray()
-        selectedMediaOptionList.forEach {
-            val jsonObject = JSONObject()
-            jsonObject.put(mediaOptionsNameJson, it.name)
-            jsonObject.put(mediaOptionsTypeJson, it.type)
-            jsonArray.put(jsonObject)
-        }
-        result.put(mediaOptionsArrayJson, jsonArray)
-        return result.toString()
     }
 
     fun setupInitialMediasFromClapprOptions() {

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -171,7 +171,7 @@ abstract class Playback(
         selectedMediaOptionList.removeAll { it.type == mediaOption.type }
         selectedMediaOptionList.add(mediaOption)
 
-        trigger(InternalEvent.MEDIA_OPTIONS_UPDATE.value)
+        trigger(Event.MEDIA_OPTIONS_UPDATE.value)
     }
 
     fun setupInitialMediasFromClapprOptions() {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -332,12 +332,10 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
         player = ExoPlayerFactory.newSimpleInstance(rendererFactory, trackSelector)
         player?.playWhenReady = false
-        player?.repeatMode = options.options[ClapprOption.LOOP.value]?.let { loop ->
-            when (loop as? Boolean ?: false) {
-                true -> Player.REPEAT_MODE_ALL
-                false -> Player.REPEAT_MODE_OFF
-            }
-        } ?: Player.REPEAT_MODE_OFF
+        player?.repeatMode = when (options.options[ClapprOption.LOOP.value]) {
+            true -> Player.REPEAT_MODE_ALL
+            else -> Player.REPEAT_MODE_OFF
+        }
 
         addListeners()
 

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -286,7 +286,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     override fun startAt(seconds: Int): Boolean {
         if (!canSeek) return false
-
         player?.seekTo((seconds * ONE_SECOND_IN_MILLIS).toLong())
         triggerPositionUpdateEvent()
 
@@ -296,7 +295,10 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     override fun seekToLivePosition(): Boolean {
         if (!canSeek) return false
 
+        trigger(Event.WILL_SEEK)
         player?.seekToDefaultPosition()
+        trigger(Event.DID_SEEK)
+        triggerPositionUpdateEvent()
         return true
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -332,6 +332,12 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
         player = ExoPlayerFactory.newSimpleInstance(rendererFactory, trackSelector)
         player?.playWhenReady = false
+        player?.repeatMode = options.options[ClapprOption.LOOP.value]?.let { loop ->
+            when (loop as? Boolean ?: false) {
+                true -> Player.REPEAT_MODE_ALL
+                false -> Player.REPEAT_MODE_OFF
+            }
+        } ?: Player.REPEAT_MODE_OFF
 
         addListeners()
 

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -416,8 +416,8 @@ open class PlayerTest {
 
         player = Player(playbackEventsToListen = mutableSetOf(playerTestEvent))
 
-        player.on(event) {
-            eventWasCalled = true
+        player.on(event) { bundle ->
+            eventWasCalled = bundle?.getBoolean(EventTestPlayback.eventBundle) ?: false
         }
 
         player.configure(Options(source = "valid"))
@@ -438,11 +438,17 @@ open class PlayerTest {
                     supportsSource = EventTestPlayback.supportsSource,
                     factory = { source, mimeType, options -> EventTestPlayback(source, mimeType, options) })
 
+            const val eventBundle = "test-bundle"
             var event: String? = null
         }
 
         override fun play(): Boolean {
-            EventTestPlayback.event?.let { trigger(it) }
+            EventTestPlayback.event?.let {
+                Bundle().apply {
+                    putBoolean(eventBundle, true)
+                    trigger(it, this)
+                }
+            }
             return super.play()
         }
     }

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -38,6 +38,7 @@ open class PlayerTest {
         Loader.register(PlayerTestPlayback.entry)
 
         PlayerTestPlayback.internalState = Playback.State.NONE
+        EventTestPlayback.event = null
 
         player = Player(playbackEventsToListen = mutableSetOf(playerTestEvent))
     }
@@ -310,6 +311,140 @@ open class PlayerTest {
         player.play()
 
         assertEquals(expectedDistinctCoreId, coreIdList.size)
+    }
+
+    @Test
+    fun shouldListenReadyEventOutOfPlayer() {
+        assertEventWasTriggered(Event.READY.value)
+    }
+
+    @Test
+    fun shouldListenErrorEventOutOfPlayer() {
+        assertEventWasTriggered(Event.ERROR.value)
+    }
+
+    @Test
+    fun shouldListenPlayingEventOutOfPlayer() {
+        assertEventWasTriggered(Event.PLAYING.value)
+    }
+
+    @Test
+    fun shouldListenDidCompleteEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_COMPLETE.value)
+    }
+
+    @Test
+    fun shouldListenDidPauseEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_PAUSE.value)
+    }
+
+    @Test
+    fun shouldListenStallingEventOutOfPlayer() {
+        assertEventWasTriggered(Event.STALLING.value)
+    }
+
+    @Test
+    fun shouldListenDidStopEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_STOP.value)
+    }
+
+    @Test
+    fun shouldListenDidSeekEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_SEEK.value)
+    }
+
+    @Test
+    fun shouldListenDidUpdateBufferEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_UPDATE_BUFFER.value)
+    }
+
+    @Test
+    fun shouldListenDidUpdatePositionEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_UPDATE_POSITION.value)
+    }
+
+    @Test
+    fun shouldListenWillPlayEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_PLAY.value)
+    }
+
+    @Test
+    fun shouldListenWillPauseEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_PAUSE.value)
+    }
+
+    @Test
+    fun shouldListenWillSeekEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_SEEK.value)
+    }
+
+    @Test
+    fun shouldListenWillStopEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_STOP.value)
+    }
+
+    @Test
+    fun shouldListenDidChangeDVRStatusEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_CHANGE_DVR_STATUS.value)
+    }
+
+    @Test
+    fun shouldListenDidChangeDVRAvailabilityEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_CHANGE_DVR_AVAILABILITY.value)
+    }
+
+    @Test
+    fun shouldListenDidUpdateBitrateEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_UPDATE_BITRATE.value)
+    }
+
+    @Test
+    fun shouldListenMediaOptionSelectedEventOutOfPlayer() {
+        assertEventWasTriggered(Event.MEDIA_OPTIONS_SELECTED.value)
+    }
+
+    @Test
+    fun shouldListenMediaOptionUpdateEventOutOfPlayer() {
+        assertEventWasTriggered(Event.MEDIA_OPTIONS_UPDATE.value)
+    }
+
+    private fun assertEventWasTriggered(event: String){
+        var eventWasCalled = false
+        Loader.register(EventTestPlayback.entry)
+
+        EventTestPlayback.event = event
+
+        player = Player(playbackEventsToListen = mutableSetOf(playerTestEvent))
+
+        player.on(event) {
+            eventWasCalled = true
+        }
+
+        player.configure(Options(source = "valid"))
+        player.play()
+
+        assertTrue(eventWasCalled)
+    }
+
+    class EventTestPlayback(source: String, mimeType: String? = null, options: Options = Options()):
+            Playback(source, mimeType, options, name = name, supportsSource = supportsSource) {
+
+        companion object {
+            const val name: String = "player_test"
+            val supportsSource: PlaybackSupportCheck = { source, _ -> source.isNotEmpty() }
+
+            val entry = PlaybackEntry(
+                    name = EventTestPlayback.name,
+                    supportsSource = EventTestPlayback.supportsSource,
+                    factory = { source, mimeType, options -> EventTestPlayback(source, mimeType, options) })
+
+            var event: String? = null
+        }
+
+        override fun play(): Boolean {
+            EventTestPlayback.event?.let { trigger(it) }
+            return super.play()
+        }
     }
 
     class PlayerTestPlayback(source: String, mimeType: String? = null, options: Options = Options()) :

--- a/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
@@ -16,8 +16,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito
+import org.mockito.*
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowApplication
@@ -62,8 +61,16 @@ open class CoreTest {
         }
     }
 
+    @Mock
+    private lateinit var frameLayoutMock: FrameLayout
+
+    @Captor
+    private lateinit var onLayoutChangeListenerCapture: ArgumentCaptor<View.OnLayoutChangeListener>
+
     @Before
     fun setup() {
+        MockitoAnnotations.initMocks(this)
+
         BaseObject.applicationContext = ShadowApplication.getInstance().applicationContext
     }
 
@@ -301,136 +308,125 @@ open class CoreTest {
 
     @Test
     fun shouldRemoveLayoutChangeListenerOnDestroy() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.destroy()
 
-        verify(mockView).removeOnLayoutChangeListener(any())
+        verify(frameLayoutMock).removeOnLayoutChangeListener(any())
     }
 
     @Test
     fun shouldAddLayoutChangeListenerOnRender() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
 
-        verify(mockView).addOnLayoutChangeListener(any())
+        verify(frameLayoutMock).addOnLayoutChangeListener(any())
     }
 
     @Test
     fun shouldRemoveBeforeAddLayoutChangeListenerOnRender() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
 
-        with(inOrder(mockView)) {
-            verify(mockView).removeOnLayoutChangeListener(any())
-            verify(mockView).addOnLayoutChangeListener(any())
+        with(inOrder(frameLayoutMock)) {
+            verify(frameLayoutMock).removeOnLayoutChangeListener(any())
+            verify(frameLayoutMock).addOnLayoutChangeListener(any())
         }
     }
 
     @Test
     fun shouldRemoveAndAddTheSameLayoutChangeListenerOnRender() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
 
-        verify(mockView).removeOnLayoutChangeListener(capture(listenerCapture))
-        verify(mockView).addOnLayoutChangeListener(listenerCapture.value)
+        verify(frameLayoutMock).removeOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(onLayoutChangeListenerCapture.value)
     }
 
     @Test
     fun shouldRemoveTheSameLayoutChangeListenerOnDestroy() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         core.destroy()
-        verify(mockView, times(2)).removeOnLayoutChangeListener(listenerCapture.value)
+        verify(frameLayoutMock, times(2))
+                .removeOnLayoutChangeListener(onLayoutChangeListenerCapture.value)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeHorizontallyToRight() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val right = 1920
         val oldRight = 1080
-        listenerCapture.value.onLayoutChange(mockView, 0, 0, right, 0, 0, 0, oldRight, 0)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 0, 0, right, 0, 0, 0, oldRight, 0)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeHorizontallyToLeft() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val left = 1920
         val oldLeft = 1080
-        listenerCapture.value.onLayoutChange(mockView, left, 0, 0, 0, oldLeft, 0, 0, 0)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, left, 0, 0, 0, oldLeft, 0, 0, 0)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeVerticallyToTop() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val top = 1920
         val oldTop = 1080
-        listenerCapture.value.onLayoutChange(mockView, 0, top, 0, 0, 0, oldTop, 0, 0)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 0, top, 0, 0, 0, oldTop, 0, 0)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeVerticallyToBottom() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val bottom = 1920
         val oldBottom = 1080
-        listenerCapture.value.onLayoutChange(mockView, 0, 0, 0, bottom, 0, 0, 0, oldBottom)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 0, 0, 0, bottom, 0, 0, 0, oldBottom)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldNotTriggerDidResizeWhenLayoutNotChangeSize() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
-        listenerCapture.value.onLayoutChange(mockView, 100, 100, 100, 100, 100, 100, 100, 100)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 100, 100, 100, 100, 100, 100, 100, 100)
 
         assertFalse(testPlugin.didResizeWasCalled)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -415,4 +415,19 @@ open class PlaybackTest {
         val playback = SomePlayback("valid-source.mp4", Options())
         assertFalse(playback.seekToLivePosition())
     }
+
+    @Test
+    fun shouldNotSentMediaOptionSelectedWhenOptionIsUpdated() {
+        var didSelectedMediaOption = false
+        val playback = SomePlayback("valid-source.mp4", Options())
+        val option = MediaOption(AudioLanguage.ORIGINAL.value, MediaOptionType.AUDIO, null, null)
+
+        playback.on(Event.MEDIA_OPTIONS_SELECTED.value) {
+            didSelectedMediaOption = true
+        }
+
+        playback.setSelectedMediaOption(option)
+
+        assertFalse(didSelectedMediaOption)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -251,7 +251,7 @@ open class PlaybackTest {
 
         var mediaOptionsUpdateCalled = false
 
-        listenObject.listenTo(playback, InternalEvent.MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateCalled = true }
+        listenObject.listenTo(playback, Event.MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateCalled = true }
 
         playback.setSelectedMediaOption(MediaOption("Name", MediaOptionType.SUBTITLE, "name", null))
 

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
@@ -44,7 +44,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerWillSeekWhenSeekToLivePositionIsCalled() {
+    fun `Should trigger WILL_SEEK when seekToLivePosition() is called`() {
         var willSeekWasCalled = false
         listenObject.listenTo(exoPlayerPlayBack, Event.WILL_SEEK.value) {
             willSeekWasCalled = true
@@ -54,7 +54,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerDidSeekWhenSeekToLivePositionIsCalled() {
+    fun `Should trigger DID_SEEK when seekToLivePosition() is called`() {
         var didSeekWasCalled = false
         listenObject.listenTo(exoPlayerPlayBack, Event.DID_SEEK.value) {
             didSeekWasCalled = true
@@ -64,7 +64,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerDidUpdatePositionWhenSeekToLivePositionIsCalled() {
+    fun `Should trigger DID_UPDATE_POSITION when seek to live position is called`() {
         var didUpdatePositionWasCalled = false
         listenObject.listenTo(exoPlayerPlayBack, Event.DID_UPDATE_POSITION.value) { bundle ->
             didUpdatePositionWasCalled = true
@@ -74,17 +74,17 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldReturnZeroBitrateWhenHistoryIsEmpty() {
+    fun `Should return zero bitrate when history is empty`() {
         assertEquals(0, exoPlayerPlayBack.bitrate)
     }
 
     @Test
-    fun shouldReturnZeroAverageBitrateWhenHistoryIsEmpty() {
+    fun `Should return zero average bitrate when history is empty`() {
         assertEquals(0, exoPlayerPlayBack.avgBitrate)
     }
 
     @Test
-    fun shouldReturnLastReportedBitrate() {
+    fun `Should return last reported bitrate`() {
         val expectedBitrate = 40L
 
         exoPlayerPlayBack.ExoplayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(10))
@@ -95,7 +95,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerDidUpdateBitrate() {
+    fun `Should trigger DID_UPDATE_BITRATE`() {
         val expectedBitrate = 40L
         var actualBitrate = 0L
 
@@ -111,7 +111,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldListeningDidUpdateOnDifferentBitrates() {
+    fun `Should listening DID_UPDATE_BITRATE on different bitrates`() {
         var numberOfTriggers = 0
 
         listenObject.listenTo(exoPlayerPlayBack, Event.DID_UPDATE_BITRATE.value) { numberOfTriggers++ }
@@ -122,7 +122,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerDidUpdateBitrateOnlyForDifferentBitrate() {
+    fun `Should trigger DID_UPDATE_BITRATE only for different bitrate`() {
         val bitrate = 10L
         var numberOfTriggers = 0
 
@@ -134,7 +134,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldNotTriggerDidUpdateBitrateWhenTrackTypeDifferentDefaultOrVideo() {
+    fun `Should not trigger DID_UPDATE_BITRATE when track type is different from TRACK_TYPE_DEFAULT or TRACK_TYPE_VIDEO`() {
         var didUpdateBitrateCalled = false
         val bitrate = 40L
 
@@ -145,7 +145,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldNotTriggerDidUpdateBitrateWhenMediaLoadDataNull() {
+    fun `Should not trigger DID_UPDATE_BITRATE when media load data is null`() {
         val mediaLoadData = null
         var didUpdateBitrateCalled = false
 
@@ -156,14 +156,14 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldHandleWrongTimeIntervalExceptionOnAddBitrateOnHistory() {
+    fun `Should handle wrong time interval exception on add bitrate on history`() {
         timeInNano = -1
 
         exoPlayerPlayBack.ExoplayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(20L))
     }
 
     @Test
-    fun shouldNotTriggerDidUpdateBitrateWhenVideoFormatNull() {
+    fun `Should not trigger DID_UPDATE_BITRATE when video format is null`() {
         val videoFormatMock = null
         val mediaLoadData = MediaSourceEventListener.MediaLoadData(0, C.TRACK_TYPE_DEFAULT, videoFormatMock, 0,
                 null, 0L, 0L)
@@ -176,7 +176,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerDidUpdateBitrateWhenTrackTypeDefault() {
+    fun `should trigger DID_UPDATE_BITRATE when TRACK_TYPE_DEFAULT`() {
         var didUpdateBitrateCalled = false
         val bitrate = 40L
 
@@ -187,7 +187,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldTriggerDidUpdateBitrateWhenTrackTypeVideo() {
+    fun `Should trigger DID_UPDATE_BITRATE when TRACK_TYPE_VIDEO`() {
         var didUpdateBitrateCalled = false
         val bitrate = 40L
 
@@ -198,7 +198,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldReturnAverageBitrate() {
+    fun `Should return average bitrate`() {
         val expectedAverageBitrate = 109L
 
         bitrateHistory.addBitrate(90, 2)
@@ -209,7 +209,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldResetBitrateHistoryAfterStopping() {
+    fun `Should reset bitrate history after stopping`() {
         bitrateHistory.addBitrate(90, 2)
         bitrateHistory.addBitrate(100, 17)
         bitrateHistory.addBitrate(110, 31)
@@ -220,7 +220,7 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
-    fun shouldResetAverageBitrateHistoryAfterStopping() {
+    fun `Should reset average bitrate history after stopping`() {
         bitrateHistory.addBitrate(90, 2)
         bitrateHistory.addBitrate(100, 17)
         bitrateHistory.addBitrate(110, 31)

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
@@ -2,6 +2,7 @@ package io.clappr.player.playback
 
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.Format
+import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.source.MediaSourceEventListener
 import io.clappr.player.BuildConfig
 import io.clappr.player.base.BaseObject
@@ -9,6 +10,7 @@ import io.clappr.player.base.Event
 import io.clappr.player.base.EventData
 import io.clappr.player.base.Options
 import io.clappr.player.bitrate.BitrateHistory
+import io.clappr.player.shadows.SimpleExoplayerShadow
 import io.clappr.player.shadows.SubtitleViewShadow
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -226,6 +228,53 @@ class ExoPlayerPlaybackTest {
         exoPlayerPlayBack.stop()
 
         assertEquals(0, exoPlayerPlayBack.avgBitrate)
+    }
+
+    @Test
+    @Config(shadows = [SimpleExoplayerShadow::class])
+    fun `Should be REPEAT_MODE_OFF when no option is passed`() {
+        val source = "supported-source.mp4"
+
+        exoPlayerPlayBack = ExoPlayerPlayback(source = source, options = Options())
+        exoPlayerPlayBack.load(source = source)
+
+        assertEquals(Player.REPEAT_MODE_OFF, SimpleExoplayerShadow.staticRepeatMode)
+    }
+
+    @Test
+    @Config(shadows = [SimpleExoplayerShadow::class])
+    fun `Should be REPEAT_MODE_OFF when invalid option is passed`() {
+        val source = "supported-source.mp4"
+        val options = Options(options = hashMapOf("loop" to "asda"))
+
+        exoPlayerPlayBack = ExoPlayerPlayback(source = source, options = options)
+        exoPlayerPlayBack.load(source = source)
+
+        assertEquals(Player.REPEAT_MODE_OFF, SimpleExoplayerShadow.staticRepeatMode)
+    }
+
+    @Test
+    @Config(shadows = [SimpleExoplayerShadow::class])
+    fun `Should be REPEAT_MODE_OFF when loop false is passed`() {
+        val source = "supported-source.mp4"
+        val options = Options(options = hashMapOf("loop" to false))
+
+        exoPlayerPlayBack = ExoPlayerPlayback(source = source, options = options)
+        exoPlayerPlayBack.load(source = source)
+
+        assertEquals(Player.REPEAT_MODE_OFF, SimpleExoplayerShadow.staticRepeatMode)
+    }
+
+    @Test
+    @Config(shadows = [SimpleExoplayerShadow::class])
+    fun `Should be REPEAT_MODE_ALL when loop true is passed`() {
+        val source = "supported-source.mp4"
+        val options = Options(options = hashMapOf("loop" to true))
+
+        exoPlayerPlayBack = ExoPlayerPlayback(source = source, options = options)
+        exoPlayerPlayBack.load(source = source)
+
+        assertEquals(Player.REPEAT_MODE_ALL, SimpleExoplayerShadow.staticRepeatMode)
     }
 
     private fun addBitrateMediaLoadData(bitrate: Long, trackType: Int = C.TRACK_TYPE_DEFAULT): MediaSourceEventListener.MediaLoadData {

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
@@ -42,6 +42,36 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
+    fun shouldTriggerWillSeekWhenSeekToLivePositionIsCalled() {
+        var willSeekWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, Event.WILL_SEEK.value) {
+            willSeekWasCalled = true
+        }
+        exoPlayerPlayBack.seekToLivePosition()
+        assertTrue("WILL_SEEK event wasn't triggered when seekToLivePosition() method was called", willSeekWasCalled)
+    }
+
+    @Test
+    fun shouldTriggerDidSeekWhenSeekToLivePositionIsCalled() {
+        var didSeekWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, Event.DID_SEEK.value) {
+            didSeekWasCalled = true
+        }
+        exoPlayerPlayBack.seekToLivePosition()
+        assertTrue("DID_SEEK event wasn't triggered when seekToLivePosition() method was called", didSeekWasCalled)
+    }
+
+    @Test
+    fun shouldTriggerDidUpdatePositionWhenSeekToLivePositionIsCalled() {
+        var didUpdatePositionWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, Event.DID_UPDATE_POSITION.value) { bundle ->
+            didUpdatePositionWasCalled = true
+        }
+        exoPlayerPlayBack.seekToLivePosition()
+        assertTrue("DID_UPDATE_POSITION event wasn't triggered when seekToLivePosition() method was called", didUpdatePositionWasCalled)
+    }
+
+    @Test
     fun shouldReturnZeroBitrateWhenHistoryIsEmpty() {
         assertEquals(0, exoPlayerPlayBack.bitrate)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/shadows/SimpleExoplayerShadow.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/shadows/SimpleExoplayerShadow.kt
@@ -1,0 +1,18 @@
+package io.clappr.player.shadows
+
+import com.google.android.exoplayer2.SimpleExoPlayer
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(SimpleExoPlayer::class)
+class SimpleExoplayerShadow {
+
+    companion object {
+        var staticRepeatMode: Int? = null
+    }
+
+    @Implementation
+    fun setRepeatMode(repeatMode: Int) {
+        staticRepeatMode = repeatMode
+    }
+}

--- a/doc/clappr/io.clappr.player.base/-clappr-option/-l-o-o-p.md
+++ b/doc/clappr/io.clappr.player.base/-clappr-option/-l-o-o-p.md
@@ -1,0 +1,14 @@
+[clappr](../../index.md) / [io.clappr.player.base](../index.md) / [ClapprOption](index.md) / [LOOP](./-l-o-o-p.md)
+
+# LOOP
+
+`LOOP`
+
+If true the video will be played forever (loop mode).
+If false the video will be stopped when it ends
+
+### Inherited Properties
+
+| Name | Summary |
+|---|---|
+| [value](value.md) | `val value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |

--- a/doc/clappr/io.clappr.player.base/-clappr-option/index.md
+++ b/doc/clappr/io.clappr.player.base/-clappr-option/index.md
@@ -16,6 +16,7 @@
 | [DRM_LICENSES](-d-r-m_-l-i-c-e-n-s-e-s.md) | Byte Array of drm licenses |
 | [MIN_DVR_SIZE](-m-i-n_-d-v-r_-s-i-z-e.md) | The minimum size in seconds to a video be considered with DVR |
 | [MEDIA_CONTROL_PLUGINS](-m-e-d-i-a_-c-o-n-t-r-o-l_-p-l-u-g-i-n-s.md) | The sequence in which the plugins will be displayed in the media control. Names are separated by commas and are case sensitive. |
+| [LOOP](-l-o-o-p.md) | If true the video will be played forever (loop mode). If false the video will be stopped when it ends |
 
 ### Properties
 

--- a/doc/clappr/io.clappr.player.base/-event/-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d.md
+++ b/doc/clappr/io.clappr.player.base/-event/-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d.md
@@ -4,7 +4,8 @@
 
 `MEDIA_OPTIONS_SELECTED`
 
-Media Options Selected. Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE](../-event-data/-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d_-r-e-s-p-o-n-s-e.md) key.
+Media Options Selected. Triggered when the user select a Media Option.
+Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE](../-event-data/-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d_-r-e-s-p-o-n-s-e.md) key.
 
 ### Inherited Properties
 

--- a/doc/clappr/io.clappr.player.base/-event/-m-e-d-i-a_-o-p-t-i-o-n-s_-u-p-d-a-t-e.md
+++ b/doc/clappr/io.clappr.player.base/-event/-m-e-d-i-a_-o-p-t-i-o-n-s_-u-p-d-a-t-e.md
@@ -1,0 +1,13 @@
+[clappr](../../index.md) / [io.clappr.player.base](../index.md) / [Event](index.md) / [MEDIA_OPTIONS_UPDATE](./-m-e-d-i-a_-o-p-t-i-o-n-s_-u-p-d-a-t-e.md)
+
+# MEDIA_OPTIONS_UPDATE
+
+`MEDIA_OPTIONS_UPDATE`
+
+Media Options Update. Triggered when the Playback load a media option
+
+### Inherited Properties
+
+| Name | Summary |
+|---|---|
+| [value](value.md) | `val value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |

--- a/doc/clappr/io.clappr.player.base/-event/index.md
+++ b/doc/clappr/io.clappr.player.base/-event/index.md
@@ -29,7 +29,8 @@
 | [REQUEST_POSTER_UPDATE](-r-e-q-u-e-s-t_-p-o-s-t-e-r_-u-p-d-a-t-e.md) | Request to update poster |
 | [WILL_UPDATE_POSTER](-w-i-l-l_-u-p-d-a-t-e_-p-o-s-t-e-r.md) | Will update poster image |
 | [DID_UPDATE_POSTER](-d-i-d_-u-p-d-a-t-e_-p-o-s-t-e-r.md) | Poster image updated |
-| [MEDIA_OPTIONS_SELECTED](-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d.md) | Media Options Selected. Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE](../-event-data/-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d_-r-e-s-p-o-n-s-e.md) key. |
+| [MEDIA_OPTIONS_SELECTED](-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d.md) | Media Options Selected. Triggered when the user select a Media Option. Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE](../-event-data/-m-e-d-i-a_-o-p-t-i-o-n-s_-s-e-l-e-c-t-e-d_-r-e-s-p-o-n-s-e.md) key. |
+| [MEDIA_OPTIONS_UPDATE](-m-e-d-i-a_-o-p-t-i-o-n-s_-u-p-d-a-t-e.md) | Media Options Update. Triggered when the Playback load a media option |
 | [DID_CHANGE_DVR_STATUS](-d-i-d_-c-h-a-n-g-e_-d-v-r_-s-t-a-t-u-s.md) | There was a change in DVR status |
 | [DID_CHANGE_DVR_AVAILABILITY](-d-i-d_-c-h-a-n-g-e_-d-v-r_-a-v-a-i-l-a-b-i-l-i-t-y.md) | There was a change in DVR availability |
 | [DID_UPDATE_BITRATE](-d-i-d_-u-p-d-a-t-e_-b-i-t-r-a-t-e.md) | Bitrate was updated |

--- a/doc/clappr/io.clappr.player.base/-internal-event/-d-i-d_-r-e-s-i-z-e.md
+++ b/doc/clappr/io.clappr.player.base/-internal-event/-d-i-d_-r-e-s-i-z-e.md
@@ -1,0 +1,11 @@
+[clappr](../../index.md) / [io.clappr.player.base](../index.md) / [InternalEvent](index.md) / [DID_RESIZE](./-d-i-d_-r-e-s-i-z-e.md)
+
+# DID_RESIZE
+
+`DID_RESIZE`
+
+### Inherited Properties
+
+| Name | Summary |
+|---|---|
+| [value](value.md) | `val value: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |

--- a/doc/clappr/io.clappr.player.base/-internal-event/index.md
+++ b/doc/clappr/io.clappr.player.base/-internal-event/index.md
@@ -38,6 +38,7 @@
 | [WILL_HIDE_MEDIA_CONTROL](-w-i-l-l_-h-i-d-e_-m-e-d-i-a_-c-o-n-t-r-o-l.md) |  |
 | [DID_HIDE_MEDIA_CONTROL](-d-i-d_-h-i-d-e_-m-e-d-i-a_-c-o-n-t-r-o-l.md) |  |
 | [DID_SHOW_MEDIA_CONTROL](-d-i-d_-s-h-o-w_-m-e-d-i-a_-c-o-n-t-r-o-l.md) |  |
+| [DID_RESIZE](-d-i-d_-r-e-s-i-z-e.md) |  |
 
 ### Properties
 

--- a/doc/clappr/io.clappr.player.base/-internal-event/index.md
+++ b/doc/clappr/io.clappr.player.base/-internal-event/index.md
@@ -24,7 +24,6 @@
 | [WILL_DESTROY](-w-i-l-l_-d-e-s-t-r-o-y.md) |  |
 | [DID_DESTROY](-d-i-d_-d-e-s-t-r-o-y.md) |  |
 | [MEDIA_OPTIONS_READY](-m-e-d-i-a_-o-p-t-i-o-n-s_-r-e-a-d-y.md) |  |
-| [MEDIA_OPTIONS_UPDATE](-m-e-d-i-a_-o-p-t-i-o-n-s_-u-p-d-a-t-e.md) |  |
 | [DID_UPDATE_OPTIONS](-d-i-d_-u-p-d-a-t-e_-o-p-t-i-o-n-s.md) |  |
 | [DID_TOUCH_MEDIA_CONTROL](-d-i-d_-t-o-u-c-h_-m-e-d-i-a_-c-o-n-t-r-o-l.md) |  |
 | [ENABLE_MEDIA_CONTROL](-e-n-a-b-l-e_-m-e-d-i-a_-c-o-n-t-r-o-l.md) |  |

--- a/doc/clappr/io.clappr.player.components/-playback/index.md
+++ b/doc/clappr/io.clappr.player.components/-playback/index.md
@@ -80,6 +80,14 @@
 |---|---|
 | [remove](../../io.clappr.player.base/-u-i-object/remove.md) | `fun remove(): `[`UIObject`](../../io.clappr.player.base/-u-i-object/index.md) |
 
+### Companion Object Properties
+
+| Name | Summary |
+|---|---|
+| [mediaOptionsArrayJson](media-options-array-json.md) | `const val mediaOptionsArrayJson: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [mediaOptionsNameJson](media-options-name-json.md) | `const val mediaOptionsNameJson: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+| [mediaOptionsTypeJson](media-options-type-json.md) | `const val mediaOptionsTypeJson: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+
 ### Inheritors
 
 | Name | Summary |

--- a/doc/clappr/io.clappr.player.components/-playback/media-options-array-json.md
+++ b/doc/clappr/io.clappr.player.components/-playback/media-options-array-json.md
@@ -1,0 +1,5 @@
+[clappr](../../index.md) / [io.clappr.player.components](../index.md) / [Playback](index.md) / [mediaOptionsArrayJson](./media-options-array-json.md)
+
+# mediaOptionsArrayJson
+
+`const val mediaOptionsArrayJson: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/doc/clappr/io.clappr.player.components/-playback/media-options-name-json.md
+++ b/doc/clappr/io.clappr.player.components/-playback/media-options-name-json.md
@@ -1,0 +1,5 @@
+[clappr](../../index.md) / [io.clappr.player.components](../index.md) / [Playback](index.md) / [mediaOptionsNameJson](./media-options-name-json.md)
+
+# mediaOptionsNameJson
+
+`const val mediaOptionsNameJson: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/doc/clappr/io.clappr.player.components/-playback/media-options-type-json.md
+++ b/doc/clappr/io.clappr.player.components/-playback/media-options-type-json.md
@@ -1,0 +1,5 @@
+[clappr](../../index.md) / [io.clappr.player.components](../index.md) / [Playback](index.md) / [mediaOptionsTypeJson](./media-options-type-json.md)
+
+# mediaOptionsTypeJson
+
+`const val mediaOptionsTypeJson: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/doc/clappr/io.clappr.player.components/-playback/selected-media-option-list.md
+++ b/doc/clappr/io.clappr.player.components/-playback/selected-media-option-list.md
@@ -2,4 +2,4 @@
 
 # selectedMediaOptionList
 
-`protected var selectedMediaOptionList: `[`ArrayList`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-array-list/index.html)`<`[`MediaOption`](../-media-option/index.md)`>`
+`var selectedMediaOptionList: `[`ArrayList`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-array-list/index.html)`<`[`MediaOption`](../-media-option/index.md)`>`


### PR DESCRIPTION
Goal
Change import fragment to use fragment android support.

How to Test
Run Unit Tests: ./gradlew clean test

1 - Open sample app
2 - Play video and ensure Media Control is working as expected